### PR TITLE
Sweep payments feature for wallet recovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "casa",
+  "name": "webcasa",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -9,7 +9,7 @@
         "qrcode": "1",
         "react": "17",
         "react-dom": "17",
-        "webcash": "1"
+        "webcash": "^1.0.6"
       },
       "devDependencies": {
         "@parcel/transformer-less": "latest",
@@ -3583,9 +3583,9 @@
       "dev": true
     },
     "node_modules/webcash": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/webcash/-/webcash-1.0.5.tgz",
-      "integrity": "sha512-LyQznDUMHMiMpGPCOO12bbyxpNK1m+vloBpFy5CeD2u356lhOhNWZH8xrsvBvEc74LR9vRLC2MgYAzPeT296/A==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/webcash/-/webcash-1.0.6.tgz",
+      "integrity": "sha512-U2YdTN8LCk/7gsAcCjTcphBQpwnlagLSoAkTCkw2etWPF/sCRCwNRJdekM/ytvITliY2AA8YPT7gWDv4/7rRtA==",
       "dependencies": {
         "@types/crypto-js": "^4.1.1",
         "create-hash": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,13 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "webcasa",
       "dependencies": {
         "crypto-js": "4",
         "qrcode": "1",
         "react": "17",
         "react-dom": "17",
-        "webcash": "^1.0.6"
+        "webcash": "1"
       },
       "devDependencies": {
         "@parcel/transformer-less": "latest",
@@ -284,9 +285,9 @@
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.0.tgz",
-      "integrity": "sha512-5qpnNHUyyEj9H3sm/4Um/bnx1lrQGhe8iqry/1d+cQYCRd/gzYA0YLeq0ezlk4hKx4vO+dsEsNyeowqRqslwQA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
+      "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
       "cpu": [
         "arm64"
       ],
@@ -297,9 +298,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.0.tgz",
-      "integrity": "sha512-ZphTFFd6SFweNAMKD+QJCrWpgkjf4qBuHltiMkKkD6FFrB3NOTRVmetAGTkJ57pa+s6J0yCH06LujWB9rZe94g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
+      "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
       "cpu": [
         "x64"
       ],
@@ -310,9 +311,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.0.tgz",
-      "integrity": "sha512-ztKVV1dO/sSZyGse0PBCq3Pk1PkYjsA/dsEWE7lfrGoAK3i9HpS2o7XjGQ7V4va6nX+xPPOiuYpQwa4Bi6vlww==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
+      "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
       "cpu": [
         "arm"
       ],
@@ -323,9 +324,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.0.tgz",
-      "integrity": "sha512-NEX6hdSvP4BmVyegaIbrGxvHzHvTzzsPaxXCsUt0mbLbPpEftsvNwaEVKOowXnLoeuGeD4MaqSwL3BUK2elsUA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
+      "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
       "cpu": [
         "arm64"
       ],
@@ -336,9 +337,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.0.tgz",
-      "integrity": "sha512-9uvdAkZMOPCY7SPRxZLW8XGqBOVNVEhqlgffenN8shA1XR9FWVsSM13nr/oHtNgXg6iVyML7RwWPyqUeThlwxg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
+      "integrity": "sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==",
       "cpu": [
         "x64"
       ],
@@ -349,9 +350,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.0.tgz",
-      "integrity": "sha512-Wg0+9615kHKlr9iLVcG5I+/CHnf6w3x5UADRv8Ad16yA0Bu5l9eVOROjV7aHPG6uC8ZPFIVVaoSjDChD+Y0pzg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
+      "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
       "cpu": [
         "x64"
       ],
@@ -1627,9 +1628,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001458",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001458.tgz",
-      "integrity": "sha512-lQ1VlUUq5q9ro9X+5gOEyH7i3vm+AYVT1WDCVB69XOZ17KZRhnZ9J0Sqz7wTHQaLBJccNCHq8/Ww5LlOIZbB0w==",
+      "version": "1.0.30001460",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001460.tgz",
+      "integrity": "sha512-Bud7abqjvEjipUkpLs4D7gR0l8hBYBHoa+tGtKJHvT2AYzLp1z7EmVkUT4ERpVUfca8S2HGIVs883D8pUH1ZzQ==",
       "dev": true,
       "funding": [
         {
@@ -1937,9 +1938,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.311",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.311.tgz",
-      "integrity": "sha512-RoDlZufvrtr2Nx3Yx5MB8jX3aHIxm8nRWPJm3yVvyHmyKaRvn90RjzB6hNnt0AkhS3IInJdyRfQb4mWhPvUjVw==",
+      "version": "1.4.318",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.318.tgz",
+      "integrity": "sha512-EQHZE/yO9Sg6gIP9VezPltDWFA8pMnv7dNRb4Y0ukels3iyXTH313gbHvK/tZwUF+jeh5F5fDf1rqWb8ZWX8fw==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2715,18 +2716,18 @@
       "optional": true
     },
     "node_modules/msgpackr": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.3.tgz",
-      "integrity": "sha512-m2JefwcKNzoHYXkH/5jzHRxAw7XLWsAdvu0FOJ+OLwwozwOV/J6UA62iLkfIMbg7G8+dIuRwgg6oz+QoQ4YkoA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.4.tgz",
+      "integrity": "sha512-BE3hD3PqV7jsNaV022uq0jMW+ZVc32wSYyQmwAoJUc+vPtCeyro2MOtAW61Fd9ZKNySM6y913E9fBY0mG+hKXg==",
       "dev": true,
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.0"
+        "msgpackr-extract": "^3.0.1"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.0.tgz",
-      "integrity": "sha512-oy6KCk1+X4Bn5m6Ycq5N1EWl9npqG/cLrE8ga8NX7ZqfqYUUBS08beCQaGq80fjbKBySur0E6x//yZjzNJDt3A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz",
+      "integrity": "sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -2737,12 +2738,12 @@
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.0",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.0",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.0",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.0",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.0",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.0"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2"
       }
     },
     "node_modules/msgpackr-extract/node_modules/node-gyp-build-optional-packages": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "qrcode": "1",
     "react": "17",
     "react-dom": "17",
-    "webcash": "1"
+    "webcash": "^1.0.6"
   },
   "devDependencies": {
     "@parcel/transformer-less": "latest",
@@ -18,7 +18,7 @@
   "scripts": {
     "serve": "parcel src/index.html",
     "build-firebase": "rm -rf dist/firebase && parcel build src/index.html --target firebase && ./scripts/bundle.sh firebase && cp src/static/* dist/firebase/",
-    "build-bundle":   "rm -rf dist/bundle   && parcel build src/index.html --target bundle",
+    "build-bundle": "rm -rf dist/bundle   && parcel build src/index.html --target bundle",
     "preview-prod": "firebase serve --only hosting:prod",
     "deploy-dev": "firebase deploy --only hosting:dev",
     "deploy-prod": "firebase deploy --only hosting:prod"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
+  "name": "webcasa",
+  "author": "juzybits <https://twitter.com/juzybits>",
   "dependencies": {
     "crypto-js": "4",
     "qrcode": "1",
     "react": "17",
     "react-dom": "17",
-    "webcash": "^1.0.6"
+    "webcash": "1"
   },
   "devDependencies": {
     "@parcel/transformer-less": "latest",
@@ -16,7 +18,7 @@
     "stream-browserify": "latest"
   },
   "scripts": {
-    "serve": "parcel src/index.html",
+    "serve": "rm -rf .parcel-cache/ dist/ && parcel src/index.html",
     "build-firebase": "rm -rf dist/firebase && parcel build src/index.html --target firebase && ./scripts/bundle.sh firebase && cp src/static/* dist/firebase/",
     "build-bundle": "rm -rf dist/bundle   && parcel build src/index.html --target bundle",
     "preview-prod": "firebase serve --only hosting:prod",

--- a/src/js/App.tsx
+++ b/src/js/App.tsx
@@ -316,7 +316,7 @@ export class App extends React.Component {
         }
     }
 
-    async onRecoverWallet(masterSecret, gapLimit) {
+    async onRecoverWallet(masterSecret, gapLimit, sweep_payments) {
         const sameSecret = masterSecret === this.state.wallet.master_secret;
         if (!sameSecret && !this.confirmOverwriteWallet()) {
             return;
@@ -349,13 +349,13 @@ export class App extends React.Component {
             }
             const wallet = new CasaWallet(walletData, password);
             wallet.setLegalAgreementsToTrue();
-            await wallet.recover(gapLimit);
+            await wallet.recover(gapLimit, sweep_payments);
             await Promise.resolve();
             wallet.save();
             this.resetAppState({wallet: wallet});
             console.log("(webcasa) Done! New balance:", formatBalance(wallet.getBalance()));
         } catch (e) {
-            const errMsg = <div className="action-error">{`ERROR: ${e.message} (masterSecret=${masterSecret}, gapLimit=${gapLimit})`}</div>;
+            const errMsg = <div className="action-error">{`ERROR: ${e.message} (masterSecret=${masterSecret}, gapLimit=${gapLimit}, sweep_payments=${sweep_payments})`}</div>;
             this.setState({ lastRecover: <ActionResult success={false} contents={errMsg} /> });
         } finally {
             window.console.log = realLog;

--- a/src/js/App.tsx
+++ b/src/js/App.tsx
@@ -316,7 +316,7 @@ export class App extends React.Component {
         }
     }
 
-    async onRecoverWallet(masterSecret, gapLimit, sweep_payments) {
+    async onRecoverWallet(masterSecret, gapLimit, sweepPayments) {
         const sameSecret = masterSecret === this.state.wallet.master_secret;
         if (!sameSecret && !this.confirmOverwriteWallet()) {
             return;
@@ -349,13 +349,13 @@ export class App extends React.Component {
             }
             const wallet = new CasaWallet(walletData, password);
             wallet.setLegalAgreementsToTrue();
-            await wallet.recover(gapLimit, sweep_payments);
+            await wallet.recover(gapLimit, sweepPayments);
             await Promise.resolve();
             wallet.save();
             this.resetAppState({wallet: wallet});
             console.log("(webcasa) Done! New balance:", formatBalance(wallet.getBalance()));
         } catch (e) {
-            const errMsg = <div className="action-error">{`ERROR: ${e.message} (masterSecret=${masterSecret}, gapLimit=${gapLimit}, sweep_payments=${sweep_payments})`}</div>;
+            const errMsg = <div className="action-error">{`ERROR: ${e.message} (masterSecret=${masterSecret}, gapLimit=${gapLimit}, sweepPayments=${sweepPayments})`}</div>;
             this.setState({ lastRecover: <ActionResult success={false} contents={errMsg} /> });
         } finally {
             window.console.log = realLog;

--- a/src/js/Navigation.tsx
+++ b/src/js/Navigation.tsx
@@ -64,6 +64,10 @@ export class Navigation extends React.Component {
                                 <i className={`nav-icon icon-twitter`}></i>
                             </a>
 
+                            <a className="social-icon" href="https://discord.com/invite/seYMuUyZus" target="_blank" aria-label="Discord">
+                                <i className={`nav-icon icon-discord`}></i>
+                            </a>
+
                             <a className="social-icon" href="https://github.com/juzybits/webcasa" target="_blank" aria-label="GitHub">
                                 <i className={`nav-icon icon-github`}></i>
                             </a>

--- a/src/js/Navigation.tsx
+++ b/src/js/Navigation.tsx
@@ -64,7 +64,7 @@ export class Navigation extends React.Component {
                                 <i className={`nav-icon icon-twitter`}></i>
                             </a>
 
-                            <a className="social-icon" href="https://discord.com/invite/seYMuUyZus" target="_blank" aria-label="Discord">
+                            <a className="social-icon" href="https://discord.gg/qf95KMqkPW" target="_blank" aria-label="Discord">
                                 <i className={`nav-icon icon-discord`}></i>
                             </a>
 

--- a/src/js/ViewRecover.tsx
+++ b/src/js/ViewRecover.tsx
@@ -11,6 +11,7 @@ export class ViewRecover extends React.Component {
         this.state = {
             masterSecret: this.initialMaster,
             gapLimit: 20,
+            sweep_payments: false,
             inProgress: false,
         };
     }
@@ -32,7 +33,8 @@ export class ViewRecover extends React.Component {
         this.setState({inProgress: true});
         const masterSecret = this.state.masterSecret;
         const gapLimit = this.state.gapLimit;
-        await this.props.onRecoverWallet(masterSecret, gapLimit);
+        const sweep_payments = this.state.sweep_payments;
+        await this.props.onRecoverWallet(masterSecret, gapLimit, sweep_payments);
         this.setState({inProgress: false});
     }
 
@@ -77,6 +79,7 @@ export class ViewRecover extends React.Component {
                 <div className="card-description">
                     <p>You can rebuild a wallet from its master secret, because webcash secrets are generated in a deterministic manner.</p>
                     <p>The "gap limit" is the maximum window span that will be used, on the assumption that any valid webcash will be found within the last item + gap limit number of secrets.</p>
+                    <p>Use "sweep payments" to also recover any pending payments that your recipients have not yet collected. This is particularly useful for self-payments.</p>
                 </div>
 
                 <form className="pure-form pure-form-stacked" onSubmit={this.onSubmit}>
@@ -94,6 +97,17 @@ export class ViewRecover extends React.Component {
                                max="1000" step="1" onChange={this.onChange}
                                disabled={this.state.inProgress}
                                spellCheck='false' autoCorrect='off' autoComplete='off'/>
+                    </fieldset>
+
+                    <fieldset>
+                        <label htmlFor="sweep_payments">sweep payments</label>
+
+                        // a boolean input defaulting to false
+                        <input type="checkbox" id="sweep_payments" defaultValue={this.state.sweep_payments}
+                               onChange={this.onChange}
+                               disabled={this.state.inProgress}
+                               autoComplete='off'
+                               />
                     </fieldset>
 
                     {submit}

--- a/src/js/ViewRecover.tsx
+++ b/src/js/ViewRecover.tsx
@@ -4,6 +4,7 @@ export class ViewRecover extends React.Component {
     constructor(props) {
         super(props)
         this.onChange = this.onChange.bind(this);
+        this.onCheckboxChange = this.onCheckboxChange.bind(this);
         this.onFocus = this.onFocus.bind(this);
         this.onSubmit = this.onSubmit.bind(this);
         this.exitOnEscape = this.exitOnEscape.bind(this);
@@ -21,6 +22,13 @@ export class ViewRecover extends React.Component {
         const target = event.target;
         this.setState({
             [target.id]: target.value
+        });
+    }
+
+    onCheckboxChange(event) {
+        const target = event.target;
+        this.setState({
+            [target.value]: target.checked
         });
     }
 
@@ -102,11 +110,10 @@ export class ViewRecover extends React.Component {
                     <fieldset>
                         <label htmlFor="sweep_payments">sweep payments</label>
 
-                        // a boolean input defaulting to false
-                        <input type="checkbox" id="sweep_payments" defaultValue={this.state.sweep_payments}
-                               onChange={this.onChange}
+                        <input type="checkbox" id="sweep_payments" value="sweep_payments"
+                               defaultChecked={this.state.sweep_payments}
+                               onChange={this.onCheckboxChange}
                                disabled={this.state.inProgress}
-                               autoComplete='off'
                                />
                     </fieldset>
 


### PR DESCRIPTION
This adds a sweep payment feature for wallet recovery.

A user reported that he made a payment to himself to sweep his funds out of one wallet and into another, and something went wrong. The wallet retained no logs of this action, and so the payment code couldn't be directly retrieved from the wallet file. One way to fix this is to add a `sweep_payments` option, as done here.

It is worth considering whether this is a good idea to introduce. It could be misused by users who pretend to make payments and then sweep back the secret. However, this was already the case anyway: any user could take a payment code they sent someone and take it for themselves. Therefore the overall harm seems minimal. The only big difference introduced here is that now users can sweep payments back into their own wallet at scale, which doesn't seem particularly problematic to me?

I could have called it `sweepPayments` to be more in line with the javascript naming conventions, but I had just implemented it over in the python wallet so the other naming convention was top of mind.

Finally, one alternative to introducing this feature is a small script to calculate the payment secret from the master secret. Users that absolutely need to do this kind of recovery could be told to do it in a shell or repl.

The discord invite link is also added back into the app in this pull request.